### PR TITLE
Anisha1234 searchbar unittest

### DIFF
--- a/web-server/v0.4/src/components/SearchBar/index.test.js
+++ b/web-server/v0.4/src/components/SearchBar/index.test.js
@@ -1,0 +1,58 @@
+import React from 'react';
+import { shallow, mount } from 'enzyme';
+import { Input, Icon } from 'antd';
+import SearchBar from './index';
+
+const { Search } = Input;
+
+const mockProps = {
+  onSearch: jest.fn(),
+  style: {
+    display: 'flex',
+    flexDirection: 'row',
+    alignContent: 'center',
+    maxWidth: 300,
+  },
+};
+
+const mockDispatch = jest.fn();
+const wrapper = shallow(<SearchBar dispatch={mockDispatch} {...mockProps} />);
+
+describe('test rendering of TableFilterSelection page component', () => {
+  it('render with empty props', () => {
+    expect(wrapper).toMatchSnapshot();
+  });
+  it('checks rendering', () => {
+    expect(wrapper.find(Search).length).toEqual(1);
+  });
+});
+
+describe('test interaction of SearchBar page component', () => {
+  it('changes search value', () => {
+    wrapper
+      .find(Search)
+      .at(0)
+      .simulate('change', { target: { value: 'mockValue' } });
+    expect(wrapper.state('searchValue')).toEqual('mockValue');
+  });
+  it('on search value', () => {
+    const onSearch = jest.fn();
+    wrapper.setProps({ onSearch });
+    wrapper
+      .find(Search)
+      .first()
+      .props()
+      .onSearch();
+    expect(onSearch).toHaveBeenCalledTimes(1);
+  });
+  it('renders Icon if search value is not empty', () => {
+    wrapper.setState({ searchValue: 'abc' });
+    expect(wrapper.find(Search).props().suffix.props).not.toBe({});
+  });
+  it('click on empty icon', () => {
+    const emitEmpty = jest.spyOn(wrapper.instance(), 'emitEmpty');
+    const click = mount(<Icon type="close-circle" onClick={emitEmpty} label="test" />);
+    click.find(Icon).prop('onClick')();
+    expect(emitEmpty).toHaveBeenCalled();
+  });
+});

--- a/web-server/v0.4/src/components/SearchBar/index.test.js
+++ b/web-server/v0.4/src/components/SearchBar/index.test.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import { shallow, mount } from 'enzyme';
-import { Input, Icon } from 'antd';
+import { Input } from 'antd';
 import SearchBar from './index';
 
 const { Search } = Input;
@@ -17,6 +17,7 @@ const mockProps = {
 
 const mockDispatch = jest.fn();
 const wrapper = shallow(<SearchBar dispatch={mockDispatch} {...mockProps} />);
+const mountedWrapper = mount(<SearchBar dispatch={mockDispatch} {...mockProps} />);
 
 describe('test rendering of TableFilterSelection page component', () => {
   it('render with empty props', () => {
@@ -28,6 +29,10 @@ describe('test rendering of TableFilterSelection page component', () => {
 });
 
 describe('test interaction of SearchBar page component', () => {
+  it('render with empty props', () => {
+    expect(mountedWrapper.find(Search)).toHaveLength(1);
+    expect(mountedWrapper.instance().searchBar).toBeTruthy();
+  });
   it('changes search value', () => {
     wrapper
       .find(Search)
@@ -49,10 +54,15 @@ describe('test interaction of SearchBar page component', () => {
     wrapper.setState({ searchValue: 'abc' });
     expect(wrapper.find(Search).props().suffix.props).not.toBe({});
   });
-  it('click on empty icon', () => {
-    const emitEmpty = jest.spyOn(wrapper.instance(), 'emitEmpty');
-    const click = mount(<Icon type="close-circle" onClick={emitEmpty} label="test" />);
-    click.find(Icon).prop('onClick')();
-    expect(emitEmpty).toHaveBeenCalled();
+  it('should clear user inputted search value', () => {
+    mountedWrapper.setState({ searchValue: 'test ' });
+    expect(
+      mountedWrapper
+        .find('Icon')
+        .at(1)
+        .prop('type')
+    ).toEqual('close-circle');
+    const icon = mountedWrapper.find('Icon').at(1);
+    icon.simulate('click');
   });
 });


### PR DESCRIPTION
@Anisha1234 I've updated the searchbar component unittests to account for full coverage of the component definition. We needed a mounted wrapper in order to obtain the searchbar ref we create within the constructor. 